### PR TITLE
Updated to bevy 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rng"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Jean Mertz <git@jeanmertz.com>"]
 edition = "2018"
 repository = "https://github.com/rustic-games/bevy_rng"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,8 @@ rand = { version = "0.8", default-features = false, features = ["getrandom"] }
 rand_seeder = "0.2"
 rand_xoshiro = "0.6"
 
-bevy = "0.5"
+bevy-stable = { package = "bevy", version = "0.5", default-features = false, optional = true }
+bevy-nightly = { package = "bevy", version = "0.5", git = "https://github.com/bevyengine/bevy", rev = "4f341430469acef478a709aff00bde375743f946", default-features = false, optional = true }
+
+[features]
+default = ["bevy-stable"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,4 @@ rand = { version = "0.8", default-features = false, features = ["getrandom"] }
 rand_seeder = "0.2"
 rand_xoshiro = "0.6"
 
-bevy-stable = { package = "bevy", version = "0.4", default-features = false, optional = true }
-bevy-nightly = { package = "bevy", version = "0.4", git = "https://github.com/bevyengine/bevy", rev = "c2a427f1a38db6b1d9798e631a7da7a8507fe18c", default-features = false, optional = true }
-
-[features]
-default = ["bevy-stable"]
+bevy = "0.5"

--- a/examples/rng.rs
+++ b/examples/rng.rs
@@ -1,3 +1,8 @@
+#[cfg(all(feature = "bevy-nightly", not(feature = "bevy-stable")))]
+use bevy_nightly as bevy;
+#[cfg(all(feature = "bevy-stable", not(feature = "bevy-nightly")))]
+use bevy_stable as bevy;
+
 use bevy::app::ScheduleRunnerSettings;
 use bevy::prelude::*;
 use bevy_rng::*;

--- a/examples/rng.rs
+++ b/examples/rng.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 fn main() {
     // Don't register the plugin (non-deterministic)...
     App::build()
-        .add_resource(ScheduleRunnerSettings::run_once())
+        .insert_resource(ScheduleRunnerSettings::run_once())
         .add_plugins(MinimalPlugins)
         .add_system(random_number_1.system())
         .add_system(random_number_2.system())
@@ -14,7 +14,7 @@ fn main() {
 
     // ...don't provide a seed (same as above)...
     App::build()
-        .add_resource(ScheduleRunnerSettings::run_once())
+        .insert_resource(ScheduleRunnerSettings::run_once())
         .add_plugins(MinimalPlugins)
         .add_plugin(RngPlugin::default())
         .add_system(random_number_1.system())
@@ -23,7 +23,7 @@ fn main() {
 
     // ...seed from u64 (deterministic)...
     App::build()
-        .add_resource(ScheduleRunnerSettings::run_once())
+        .insert_resource(ScheduleRunnerSettings::run_once())
         .add_plugins(MinimalPlugins)
         .add_plugin(RngPlugin::from(42))
         .add_system(random_number_1.system())
@@ -32,7 +32,7 @@ fn main() {
 
     // ...or from a string (same as above).
     App::build()
-        .add_resource(ScheduleRunnerSettings::run_loop(Duration::from_millis(100)))
+        .insert_resource(ScheduleRunnerSettings::run_loop(Duration::from_millis(100)))
         .add_plugins(MinimalPlugins)
         .add_plugin(RngPlugin::from("your seed here"))
         .add_system(random_number_1.system())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,13 @@ use rand_seeder::Seeder;
 use rand_xoshiro::Xoshiro256StarStar;
 use std::ops::{Deref, DerefMut};
 
+#[cfg(all(feature = "bevy-nightly", not(feature = "bevy-stable")))]
+use bevy_nightly as bevy;
+#[cfg(all(feature = "bevy-stable", not(feature = "bevy-nightly")))]
+use bevy_stable as bevy;
+
 use bevy::prelude::*;
+
 
 pub use rand::Rng as _;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,6 @@ use rand_seeder::Seeder;
 use rand_xoshiro::Xoshiro256StarStar;
 use std::ops::{Deref, DerefMut};
 
-#[cfg(all(feature = "bevy-nightly", not(feature = "bevy-stable")))]
-use bevy_nightly as bevy;
-#[cfg(all(feature = "bevy-stable", not(feature = "bevy-nightly")))]
-use bevy_stable as bevy;
-
 use bevy::prelude::*;
 
 pub use rand::Rng as _;
@@ -69,10 +64,7 @@ impl Plugin for RngPlugin {
             None => Xoshiro256StarStar::from_entropy(),
         };
 
-        #[cfg(all(feature = "bevy-nightly", not(feature = "bevy-stable")))]
         app.insert_resource(RootRng { rng });
-        #[cfg(all(feature = "bevy-stable", not(feature = "bevy-nightly")))]
-        app.add_resource(RootRng { rng });
     }
 }
 
@@ -105,10 +97,10 @@ impl DerefMut for Rng {
     }
 }
 
-impl FromResources for Rng {
-    fn from_resources(resources: &Resources) -> Self {
-        let inner = match resources.get_mut::<RootRng>() {
-            Some(mut rng) => Xoshiro256StarStar::from_rng(&mut rng.deref_mut().rng)
+impl FromWorld for Rng {
+    fn from_world(world: &mut World) -> Self {
+        let inner = match world.get_resource::<RootRng>() {
+            Some(rng) => Xoshiro256StarStar::from_rng(rng.rng.clone())
                 .expect("failed to create rng"),
             None => Xoshiro256StarStar::from_entropy(),
         };


### PR DESCRIPTION
Bevy 0.5 was released on April 6th, and with it came some breaking changes to how Local resources work; specifically that the resource struct should now implement `FromWorld` rather than the now removed `FromResources`, and that `AppBuilder.insert_resource` is now in stable.